### PR TITLE
Use named import (alias) for go.opentelemetry.io/otel/codes

### DIFF
--- a/instrument/open_telemetry.go
+++ b/instrument/open_telemetry.go
@@ -3,6 +3,7 @@ package instrument
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 )
 
 type OpenTelemetry struct {
@@ -14,17 +15,17 @@ type OpenTelemetry struct {
 	hasError   bool
 }
 
-func (s *OpenTelemetry) Imports() []string {
+func (s *OpenTelemetry) Imports() []*types.Package {
 	if !s.hasInserts {
 		return nil
 	}
-	pkg := []string{
-		"go.opentelemetry.io/otel",
+	pkgs := []*types.Package{
+		types.NewPackage("go.opentelemetry.io/otel", ""),
 	}
 	if s.hasError {
-		pkg = append(pkg, "go.opentelemetry.io/otel/codes")
+		pkgs = append(pkgs, types.NewPackage("go.opentelemetry.io/otel/codes", "otelCodes"))
 	}
-	return pkg
+	return pkgs
 }
 
 func (s *OpenTelemetry) PrefixStatements(spanName string, hasError bool) []ast.Stmt {
@@ -72,7 +73,7 @@ func (s *OpenTelemetry) exprFuncSetSpanError(errorName string) ast.Expr {
 					&ast.ExprStmt{X: &ast.CallExpr{
 						Fun: &ast.SelectorExpr{X: &ast.Ident{Name: "span"}, Sel: &ast.Ident{Name: "SetStatus"}},
 						Args: []ast.Expr{
-							&ast.SelectorExpr{X: &ast.Ident{Name: "codes"}, Sel: &ast.Ident{Name: "Error"}},
+							&ast.SelectorExpr{X: &ast.Ident{Name: "otelCodes"}, Sel: &ast.Ident{Name: "Error"}},
 							&ast.BasicLit{Kind: token.STRING, Value: `"error"`},
 						},
 					}},

--- a/instrument/open_telemetry_test.go
+++ b/instrument/open_telemetry_test.go
@@ -32,12 +32,12 @@ func TestOpenTelemetry_Error(t *testing.T) {
 	}
 
 	expImports := map[string]bool{
-		"go.opentelemetry.io/otel":       true,
-		"go.opentelemetry.io/otel/codes": true,
+		"go.opentelemetry.io/otel ":                true,
+		"go.opentelemetry.io/otel/codes otelCodes": true,
 	}
 	imports := p.Imports()
-	for _, q := range imports {
-		if !expImports[q] {
+	for _, pkg := range imports {
+		if !expImports[pkg.Path()+" "+pkg.Name()] {
 			t.Errorf("wrong import")
 		}
 	}
@@ -64,8 +64,8 @@ func TestOpenTelemetry(t *testing.T) {
 		"go.opentelemetry.io/otel": true,
 	}
 	imports := p.Imports()
-	for _, q := range imports {
-		if !expImports[q] {
+	for _, pkg := range imports {
+		if !expImports[pkg.Path()+pkg.Name()] {
 			t.Errorf("wrong import")
 		}
 	}

--- a/instrument/testdata/open_telemetry_error.go
+++ b/instrument/testdata/open_telemetry_error.go
@@ -2,7 +2,7 @@ ctx, span := otel.Tracer("app").Start(ctx, "myClass.MyFunction")
 defer span.End()
 defer func() {
 	if err != nil {
-		span.SetStatus(codes.Error, "error")
+		span.SetStatus(otelCodes.Error, "error")
 		span.RecordError(err)
 	}
 }()

--- a/internal/testdata/instrumented/basic.go.exp
+++ b/internal/testdata/instrumented/basic.go.exp
@@ -3,7 +3,7 @@ package example
 import (
 	"context"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/codes"
+	otelCodes "go.opentelemetry.io/otel/codes"
 )
 
 func AnonymousFuncWithoutContext() func() (name string, err error) {
@@ -18,7 +18,7 @@ func AnonymousFunc() func(ctx context.Context) (name string, err error) {
 		defer span.End()
 		defer func() {
 			if err != nil {
-				span.SetStatus(codes.Error, "error")
+				span.SetStatus(otelCodes.Error, "error")
 				span.RecordError(err)
 			}
 		}()
@@ -43,7 +43,7 @@ func (s Cat) Name(ctx context.Context) (name string, err error) {
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()
@@ -58,7 +58,7 @@ func (s *Apple) MethodWithPointerReciver(ctx context.Context, a int) (err error)
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()
@@ -71,7 +71,7 @@ func (s Apple) MethodWithValueReciver(ctx context.Context, a int) (err error) {
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()
@@ -84,7 +84,7 @@ func (*Apple) MethodWithPointerReciverUnnamed(ctx context.Context, a int) (err e
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()
@@ -97,7 +97,7 @@ func (Apple) MethodWithValueReciverUnnamed(ctx context.Context, a int) (err erro
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()
@@ -123,7 +123,7 @@ func Basic(ctx context.Context) (err error) {
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()

--- a/internal/testdata/instrumented/basic_include_only.go.exp
+++ b/internal/testdata/instrumented/basic_include_only.go.exp
@@ -3,7 +3,7 @@ package example
 import (
 	"context"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/codes"
+	otelCodes "go.opentelemetry.io/otel/codes"
 )
 
 //instrument:include Bark
@@ -15,7 +15,7 @@ func (s Dog) Bark(ctx context.Context) (name string, err error) {
 	defer span.End()
 	defer func() {
 		if err != nil {
-			span.SetStatus(codes.Error, "error")
+			span.SetStatus(otelCodes.Error, "error")
 			span.RecordError(err)
 		}
 	}()

--- a/main_test.go
+++ b/main_test.go
@@ -28,7 +28,7 @@ func FuzzBadFile(f *testing.F) {
 	})
 }
 
-func TestMain(t *testing.T) {
+func TestApp(t *testing.T) {
 	testbin := path.Join(t.TempDir(), "go-instrument-testbin")
 	exec.Command("go", "build", "-cover", "-o", testbin, "main.go").Run()
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -3,13 +3,14 @@ package processor
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 
 	"golang.org/x/tools/go/ast/astutil"
 )
 
 // Instrumenter supplies ast of Go code that will be inserted and required dependencies.
 type Instrumenter interface {
-	Imports() []string
+	Imports() []*types.Package
 	PrefixStatements(spanName string, hasError bool) []ast.Stmt
 }
 
@@ -188,8 +189,8 @@ func (p *Processor) Process(fset *token.FileSet, file *ast.File) error {
 			return err
 		}
 
-		for _, q := range p.Instrumenter.Imports() {
-			astutil.AddImport(fset, file, q)
+		for _, pkg := range p.Instrumenter.Imports() {
+			astutil.AddNamedImport(fset, file, pkg.Name(), pkg.Path())
 		}
 	}
 


### PR DESCRIPTION
With "codes" being a popular module name (e.g. `google.golang.org/grpc/codes`), the tool can produce the code that does not compile because of an import clash.
The solution is to use the named import (alias) for `go.opentelemetry.io/otel/codes`, so that one doesn't need to modify it's own source code.