### PR TITLE
Add detection if targeted file already injected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@
 # vendor/
 
 go-instrument
-
-/repomix.config.json
-/repomix-output.md

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # vendor/
 
 go-instrument
+
+/repomix.config.json
+/repomix-output.md

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path"
@@ -93,6 +94,47 @@ func TestApp(t *testing.T) {
 		cmd.Env = append(cmd.Environ(), "GOCOVERDIR=./coverage")
 		if err := cmd.Run(); err == nil {
 			t.Errorf("expected exit code 1")
+		}
+	})
+}
+
+func TestApp_UninstrumentedFile(t *testing.T) {
+	testbin := path.Join(t.TempDir(), "go-instrument-testbin")
+	exec.Command("go", "build", "-cover", "-o", testbin, "main.go").Run()
+
+	t.Run("when uninstrumented, injects code", func(t *testing.T) {
+		// Copy the uninstrumented test file
+		f := copyFile(t, "./internal/testdata/basic.go")
+
+		cmd := exec.Command(testbin, "-app", "app", "-w", "-filename", f)
+		cmd.Env = append(cmd.Environ(), "GOCOVERDIR=./coverage")
+		if err := cmd.Run(); err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		// Verify the output matches the expected instrumented version
+		assertEqFile(t, "./internal/testdata/instrumented/basic.go.exp", f)
+	})
+}
+
+func TestApp_AlreadyInstrumentedFile(t *testing.T) {
+	testbin := path.Join(t.TempDir(), "go-instrument-testbin")
+	exec.Command("go", "build", "-cover", "-o", testbin, "main.go").Run()
+
+	t.Run("when already instrumented, skips injection", func(t *testing.T) {
+		// Use the already instrumented file as input
+		f := copyFile(t, "./internal/testdata/instrumented/basic.go.exp")
+		originalContent, _ := os.ReadFile(f)
+
+		cmd := exec.Command(testbin, "-app", "app", "-w", "-filename", f)
+		cmd.Env = append(cmd.Environ(), "GOCOVERDIR=./coverage")
+		if err := cmd.Run(); err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		newContent, _ := os.ReadFile(f)
+		if !bytes.Equal(originalContent, newContent) {
+			t.Errorf("File was modified despite existing instrumentation")
 		}
 	})
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -202,7 +202,7 @@ func (p *Processor) isFunctionInstrumented(body *ast.BlockStmt) bool {
 
 	// Check first statement: ctx, span := otel.Tracer(...).Start(...)
 	assignStmt, ok := body.List[0].(*ast.AssignStmt)
-	if !ok || len(assignStmt.Lhs) != 2 || len(assignStmt.Rhs) != 1 {
+	if !ok || assignStmt == nil || len(assignStmt.Lhs) != 2 || len(assignStmt.Rhs) != 1 {
 		return false
 	}
 	ctxIdent, ok1 := assignStmt.Lhs[0].(*ast.Ident)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -171,6 +171,10 @@ func (p *Processor) Process(fset *token.FileSet, file *ast.File) error {
 		}
 
 		if p.functionHasContext(fnType) {
+			if p.isFunctionInstrumented(fnBody) {
+				return true
+			}
+
 			hasError, errorName := p.functionHasError(fnType)
 			ps := p.Instrumenter.PrefixStatements(p.SpanName(receiver, fname), hasError, errorName)
 			patches = append(patches, patch{pos: fnBody.Pos(), stmts: ps})
@@ -189,4 +193,33 @@ func (p *Processor) Process(fset *token.FileSet, file *ast.File) error {
 	}
 
 	return nil
+}
+
+func (p *Processor) isFunctionInstrumented(body *ast.BlockStmt) bool {
+	if body == nil || len(body.List) < 2 {
+		return false
+	}
+
+	// Check first statement: ctx, span := otel.Tracer(...).Start(...)
+	assignStmt, ok := body.List[0].(*ast.AssignStmt)
+	if !ok || len(assignStmt.Lhs) != 2 || len(assignStmt.Rhs) != 1 {
+		return false
+	}
+	ctxIdent, ok1 := assignStmt.Lhs[0].(*ast.Ident)
+	spanIdent, ok2 := assignStmt.Lhs[1].(*ast.Ident)
+	if !ok1 || !ok2 || ctxIdent.Name != p.ContextName || spanIdent.Name != "span" {
+		return false
+	}
+
+	// Check second statement: defer span.End()
+	deferStmt, ok := body.List[1].(*ast.DeferStmt)
+	if !ok {
+		return false
+	}
+	callExpr, ok := deferStmt.Call.Fun.(*ast.SelectorExpr)
+	if !ok || callExpr.Sel.Name != "End" {
+		return false
+	}
+	spanVar, ok := callExpr.X.(*ast.Ident)
+	return ok && spanVar.Name == "span"
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -217,7 +217,7 @@ func (p *Processor) isFunctionInstrumented(body *ast.BlockStmt) bool {
 		return false
 	}
 	callExpr, ok := deferStmt.Call.Fun.(*ast.SelectorExpr)
-	if !ok || callExpr.Sel.Name != "End" {
+	if !ok || callExpr == nil || callExpr.Sel.Name != "End" {
 		return false
 	}
 	spanVar, ok := callExpr.X.(*ast.Ident)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -207,7 +207,7 @@ func (p *Processor) isFunctionInstrumented(body *ast.BlockStmt) bool {
 	}
 	ctxIdent, ok1 := assignStmt.Lhs[0].(*ast.Ident)
 	spanIdent, ok2 := assignStmt.Lhs[1].(*ast.Ident)
-	if !ok1 || !ok2 || ctxIdent.Name != p.ContextName || spanIdent.Name != "span" {
+	if !ok1 || !ok2 || ctxIdent == nil || spanIdent == nil || ctxIdent.Name != p.ContextName || spanIdent.Name != "span" {
 		return false
 	}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -213,7 +213,7 @@ func (p *Processor) isFunctionInstrumented(body *ast.BlockStmt) bool {
 
 	// Check second statement: defer span.End()
 	deferStmt, ok := body.List[1].(*ast.DeferStmt)
-	if !ok {
+	if !ok || deferStmt == nil { 
 		return false
 	}
 	callExpr, ok := deferStmt.Call.Fun.(*ast.SelectorExpr)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -221,5 +221,5 @@ func (p *Processor) isFunctionInstrumented(body *ast.BlockStmt) bool {
 		return false
 	}
 	spanVar, ok := callExpr.X.(*ast.Ident)
-	return ok && spanVar.Name == "span"
+	return ok && spanVar != nil && spanVar.Name == "span"
 }


### PR DESCRIPTION
This PR intent is to implement ability to detect wether targeted file already injected or not. 

so that,
running this tools multiple times in a repo will not be have any impact to previously edited file.

This will bring benefit, if repo is growth overtime. New developer will only need to run again this tools, and it will injected to newfile and ignoring older file that already injected.